### PR TITLE
Support continuous deployment with CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Bamboo.PostMarkAdapter
+# Bamboo.PostmarkAdapter
+
+[![CircleCI](https://circleci.com/gh/pablo-co/bamboo_postmark.svg?style=svg)](https://circleci.com/gh/pablo-co/bamboo_postmark)
 
 A [Postmark](https://postmarkapp.com/) Adapter for the [Bamboo](https://github.com/thoughtbot/bamboo) email library.
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,17 @@
+machine:
+  environment:
+    PATH: "$HOME/.asdf/bin:$HOME/.asdf/shims:$PATH"
+
+dependencies:
+  cache_directories:
+    - ~/.asdf
+    - deps
+    - _build
+  pre:
+    - ./circle_pre_build.sh
+    - mix deps.compile
+    - mix compile
+
+test:
+  override:
+    - mix test

--- a/circle_pre_build.sh
+++ b/circle_pre_build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Ensure exit codes other than 0 fail the build
+set -e
+
+# Check for asdf
+if ! asdf | grep version; then
+  git clone https://github.com/HashNuke/asdf.git ~/.asdf;
+fi
+
+# Add plugins for asdf
+if ! asdf plugin-list | grep erlang; then
+  asdf plugin-add erlang https://github.com/HashNuke/asdf-erlang.git
+fi
+
+if ! asdf plugin-list | grep elixir; then
+  asdf plugin-add elixir https://github.com/HashNuke/asdf-elixir.git
+fi
+
+# Extract vars from elixir_buildpack.config
+. elixir_buildpack.config
+
+# Write .tool-versions
+echo "erlang $erlang_version" >> .tool-versions
+echo "elixir $elixir_version" >> .tool-versions
+
+# Install erlang/elixir
+asdf install erlang $erlang_version
+asdf install elixir $elixir_version
+
+# Get dependencies
+yes | mix deps.get
+yes | mix local.rebar
+
+# Exit successfully
+exit 0

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,0 +1,2 @@
+erlang_version=19.0
+elixir_version=1.3.2


### PR DESCRIPTION
To do the configuration for erlang and Elixir we are using a bash script
that makes use of `[asdf][1]`.
