### PR TITLE
Fix typo for PostmarkHelper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ email.
 
 ```elixir
 defmodule MyApp.Mail do
-  import Bamboo.PostMarkHelper
+  import Bamboo.PostmarkHelper
 
   def some_email do
     email


### PR DESCRIPTION
The README incorrectly states `Bamboo.PostMarkHelper` as the module name
to import when using Postmark's templates. This change uses the correct
module name `Bamboo.PostmarkHelper`.
