### PR TITLE
Fix formatting of multiple recipients

### DIFF
--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -142,7 +142,7 @@ defmodule Bamboo.PostmarkAdapter do
   defp recipients_to_string(recipients, type) do
     recipients
     |> Enum.filter(fn(recipient) -> recipient[:type] == type end)
-    |> Enum.map_join(",", fn(rec) -> "#{rec[:name]} #{rec[:email]}" end)
+    |> Enum.map_join(",", fn(rec) -> "#{rec[:name]} <#{rec[:email]}>" end)
   end
 
   defp headers(api_key) do

--- a/test/lib/bamboo/postmark_adapter_test.exs
+++ b/test/lib/bamboo/postmark_adapter_test.exs
@@ -127,9 +127,9 @@ defmodule Bamboo.PostmarkAdapterTest do
     email |> PostmarkAdapter.deliver(@config)
 
     assert_receive {:fake_postmark, %{params: params}}
-    assert params["To"] == "To to@bar.com"
-    assert params["Bcc"] == "BCC bcc@bar.com"
-    assert params["Cc"] == "CC cc@bar.com"
+    assert params["To"] == "To <to@bar.com>"
+    assert params["Bcc"] == "BCC <bcc@bar.com>"
+    assert params["Cc"] == "CC <cc@bar.com>"
   end
 
   test "deliver/2 puts template name and empty content" do


### PR DESCRIPTION
Currently we are formatting multiple recipients as "name email, name
email". According to the Postmark API the expect format is "name
<email>". This change fixes the formatting of multiple emails recipients.
