### PR TITLE
Support email tagging 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ defmodule MyApp.Mail do
   end
 end
 ```
+
 #### Exception Warning
 
 Postmark templates include a subject, HTML body and text body and thus these shouldn't be included in the email as they will raise an API exception.
@@ -71,4 +72,21 @@ email
 |> subject("Will raise exception")
 |> html_body("<p>Will raise exception</p>")
 |> text_body("Will raise exception")
+```
+
+## Tagging emails
+
+The Postmark adapter provides a helper module for tagging emails.
+
+### Example
+
+```elixir
+defmodule MyApp.Mail do
+  import Bamboo.PostmarkHelper
+
+  def some_email do
+    email
+    |> tag("some-tag")
+  end
+end
 ```

--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -77,7 +77,10 @@ defmodule Bamboo.PostmarkAdapter do
   end
 
   defp convert_to_postmark_params(email) do
-    email_params(email) |> maybe_put_template_params(email)
+    email
+    |> email_params()
+    |> maybe_put_template_params(email)
+    |> maybe_put_tag_params(email)
   end
 
   defp maybe_put_template_params(params, %{private:
@@ -89,6 +92,14 @@ defmodule Bamboo.PostmarkAdapter do
   end
 
   defp maybe_put_template_params(params, _) do
+    params
+  end
+
+  defp maybe_put_tag_params(params, %{private: %{tag: tag}}) do
+    Map.put(params, :"Tag", tag)
+  end
+
+  defp maybe_put_tag_params(params, _) do
     params
   end
 
@@ -119,7 +130,7 @@ defmodule Bamboo.PostmarkAdapter do
 
   defp email_headers(email) do
     Enum.map(email.headers,
-              fn {header, value} -> %{"Name": header, "Value": value } end)
+              fn {header, value} -> %{"Name": header, "Value": value} end)
   end
 
   defp recipients(email) do

--- a/lib/bamboo/postmark_helper.ex
+++ b/lib/bamboo/postmark_helper.ex
@@ -6,6 +6,18 @@ defmodule Bamboo.PostmarkHelper do
   alias Bamboo.Email
 
   @doc """
+  Set a single tag for an email that allows you to categorize outgoing emails
+  and get detailed statistics.
+
+  A convenience function for `put_private(email, :tag, "my-tag")`
+  ## Example
+      tag(email, "welcome-email")
+  """
+  def tag(email, tag) do
+    Email.put_private(email, :tag, tag)
+  end
+
+  @doc """
   Send emails using Postmark's template API.
 
   Setup Postmark to send emails using a template. Use this in conjuction with

--- a/test/lib/bamboo/postmark_adapter_test.exs
+++ b/test/lib/bamboo/postmark_adapter_test.exs
@@ -157,6 +157,14 @@ defmodule Bamboo.PostmarkAdapterTest do
       "name" => 'example name'}]
   end
 
+  test "deliver/2 puts tag param" do
+     email = new_email |> PostmarkHelper.tag("some_tag")
+
+     email |> PostmarkAdapter.deliver(@config)
+
+     assert_receive {:fake_postmark, %{params: %{"Tag" => "some_tag"}}}
+  end
+
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 


### PR DESCRIPTION
Email tags allow you to categorize outgoing emails and get detailed
statistics about them. This change adds the `tag` function to
`PostmarkHelper`. This tag is later added to the HTTP request as the
`Tag` param.