### PR TITLE
Add Postmark email opens and links tracking options

### DIFF
--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -104,7 +104,7 @@ defmodule Bamboo.PostmarkAdapter do
     params
   end
 
-  defp maybe_put_tracking_params(params, %{private: 
+  defp maybe_put_tracking_params(params, %{private:
     %{track_opens: track_opens, track_links: track_links}}) do
     params
     |> Map.put(:"TrackOpens", track_opens)

--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -81,6 +81,7 @@ defmodule Bamboo.PostmarkAdapter do
     |> email_params()
     |> maybe_put_template_params(email)
     |> maybe_put_tag_params(email)
+    |> maybe_put_tracking_params(email)
   end
 
   defp maybe_put_template_params(params, %{private:
@@ -103,6 +104,17 @@ defmodule Bamboo.PostmarkAdapter do
     params
   end
 
+  defp maybe_put_tracking_params(params, %{private: 
+    %{track_opens: track_opens, track_links: track_links}}) do
+    params
+    |> Map.put(:"TrackOpens", track_opens)
+    |> Map.put(:"TrackLinks", track_links)
+  end
+
+  defp maybe_put_tracking_params(params, _) do
+    params
+  end
+
   defp email_params(email) do
     recipients = recipients(email)
     %{
@@ -113,8 +125,7 @@ defmodule Bamboo.PostmarkAdapter do
       "Subject": email.subject,
       "TextBody": email.text_body,
       "HtmlBody": email.html_body,
-      "Headers": email_headers(email),
-      "TrackOpens": true
+      "Headers": email_headers(email)
     }
   end
 

--- a/lib/bamboo/postmark_helper.ex
+++ b/lib/bamboo/postmark_helper.ex
@@ -35,4 +35,17 @@ defmodule Bamboo.PostmarkHelper do
     |> Email.put_private(:template_id, template_id)
     |> Email.put_private(:template_model, template_model)
   end
+
+  @doc """
+  Enable Postmark email open tracking and link tracking.
+
+  ## Example
+    tracking(email, opens: true, links: "HtmlAndText")
+  """
+  def tracking(email, options) do
+    %{opens: opens, links: links} = Map.merge(%{opens: false, links: "None"}, options)
+    email
+    |> Email.put_private(:track_opens, opens)
+    |> Email.put_private(:track_links, links)
+  end
 end

--- a/test/lib/bamboo/postmark_adapter_test.exs
+++ b/test/lib/bamboo/postmark_adapter_test.exs
@@ -165,6 +165,14 @@ defmodule Bamboo.PostmarkAdapterTest do
      assert_receive {:fake_postmark, %{params: %{"Tag" => "some_tag"}}}
   end
 
+  test "deliver/2 puts tracking params" do
+     email = new_email() |> PostmarkHelper.tracking(%{opens: true, links: "HtmlOnly"})
+
+     email |> PostmarkAdapter.deliver(@config)
+
+     assert_receive {:fake_postmark, %{params: %{"TrackLinks" => "HtmlOnly", "TrackOpens" => true}}}
+  end
+
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 


### PR DESCRIPTION
Hopefully the api is fine.

Do you think the adapter should throw if TrackLinks option is not one of the possible values "None", "HtmlOnly", "TextOnly" or "HtmlAndText"?

http://developer.postmarkapp.com/developer-api-email.html