### PR TITLE
Allow configuration of request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ end
 #  * Recommended production only: config/prod.exs
 
 config :my_app, MyApp.Mailer,
-      adapter: Bamboo.PostmarkAdapter
+      adapter: Bamboo.PostmarkAdapter,
       api_key: "my_api_key"
 ```
 
@@ -102,4 +102,19 @@ TrackLinks by using `put_params`.
 email
 |> put_params("TrackLinks", "HtmlAndText")
 |> put_params("TrackOpens", true)
+```
+
+## Changing the underlying request configuration
+
+You can specify the options that are passed to the underlying HTTP client
+[hackney](https://github.com/benoitc/hackney) by using the `request_options` key
+in the configuration.
+
+### Example
+
+```elixir
+config :my_app, MyApp.Mailer,
+      adapter: Bamboo.PostmarkAdapter,
+      api_key: "my_api_key",
+      request_options: [recv_timeout: 10_000]
 ```

--- a/lib/bamboo/postmark_helper.ex
+++ b/lib/bamboo/postmark_helper.ex
@@ -40,6 +40,7 @@ defmodule Bamboo.PostmarkHelper do
   Put extra message parameters that are used by Postmark. You can set things like TrackOpens or TrackLinks.
 
   ## Example
+
     put_params(email, "TrackLinks", "HtmlAndText")
     put_params(email, "TrackOpens", true)
   """
@@ -49,5 +50,4 @@ defmodule Bamboo.PostmarkHelper do
   def put_param(email, key, value) do
     email |> Email.put_private(:message_params, %{}) |> put_param(key, value)
   end
-
 end

--- a/test/lib/bamboo/postmark_adapter_test.exs
+++ b/test/lib/bamboo/postmark_adapter_test.exs
@@ -81,7 +81,16 @@ defmodule Bamboo.PostmarkAdapterTest do
     end
   end
 
-  test "deliver/2 sends the to the right url" do
+  test "deliver/2 passes the request_options to hackney" do
+    request_options = [recv_timeout: 0]
+    config = Map.put(@config, :request_options, request_options)
+
+    assert_raise Bamboo.PostmarkAdapter.ApiError, fn ->
+      PostmarkAdapter.deliver(new_email(), config)
+    end
+  end
+
+  test "deliver/2 makes the request to the right url" do
     new_email() |> PostmarkAdapter.deliver(@config)
 
     assert_receive {:fake_postmark, %{request_path: request_path}}


### PR DESCRIPTION
In some cases it might be useful being able to specify the options that
are sent to hackney such as the request timeout. This change introduces
support for such cases through the configuration hash.