### PR TITLE
Return body in response of PostmarkAdapter.deliver

### DIFF
--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -177,6 +177,6 @@ defmodule Bamboo.PostmarkAdapter do
   end
 
   defp options(config) do
-    config[:request_options] || []
+    Keyword.merge(config[:request_options] || [], [with_body: true])
   end
 end

--- a/test/lib/bamboo/postmark_adapter_test.exs
+++ b/test/lib/bamboo/postmark_adapter_test.exs
@@ -90,6 +90,12 @@ defmodule Bamboo.PostmarkAdapterTest do
     end
   end
 
+  test "deliver/2 returns the textual body of the request" do
+    response = PostmarkAdapter.deliver(new_email(), @config)
+
+    assert response.body == "SENT"
+  end
+
   test "deliver/2 makes the request to the right url" do
     new_email() |> PostmarkAdapter.deliver(@config)
 


### PR DESCRIPTION
In 10bd20e the `with_body` request option was accidentally removed from
`PostmarkAdapter.deliver/2`.

This change restores this option and adds a test to verify that the
textual body is returned instead of the reference.