### PR TITLE
Default template model should be struct not array

### DIFF
--- a/lib/bamboo/postmark_helper.ex
+++ b/lib/bamboo/postmark_helper.ex
@@ -24,14 +24,14 @@ defmodule Bamboo.PostmarkHelper do
   Setup Postmark to send emails using a template. Use this in conjuction with
   the template content to offload template rendering to Postmark. The
   template id specified here must match the template id in Postmark.
-  Postmarks's API docs for this can be found [here](https://www.mandrillapp.com/api/docs/messages.JSON.html#method=send-template).
+  Postmarks's API docs for this can be found [here](https://postmarkapp.com/developer/api/templates-api#email-with-template).
 
   ## Example
 
     template(email, "9746128")
     template(email, "9746128", %{"name" => "Name", "content" => "John"})
   """
-  def template(email, template_id, template_model \\ []) do
+  def template(email, template_id, template_model \\ %{}) do
     email
     |> Email.put_private(:template_id, template_id)
     |> Email.put_private(:template_model, template_model)

--- a/test/lib/bamboo/postmark_adapter_test.exs
+++ b/test/lib/bamboo/postmark_adapter_test.exs
@@ -157,7 +157,7 @@ defmodule Bamboo.PostmarkAdapterTest do
     assert_receive {:fake_postmark, %{params: %{"TemplateId" => template_id,
        "TemplateModel" => template_model}}}
     assert template_id == "hello"
-    assert template_model == []
+    assert template_model == %{}
   end
 
   test "deliver/2 puts template name and content" do


### PR DESCRIPTION
Postmark returns an error if an array is sent as the template model.
Empty struct works fine. This was causing the following error when
calling `PostmarkHelper.template` with no model :

``` json
{"ErrorCode":403,"Message":"Received valid, but incompatible JSON input."}
```