### PR TITLE
Relax library requirements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,8 +22,8 @@ defmodule BambooPostmark.Mixfile do
   end
 
   defp deps do
-    [{:bamboo, "~> 0.5"},
-     {:hackney, "~> 1.6"},
+    [{:bamboo, ">= 0.5"},
+     {:hackney, ">= 1.6"},
      {:poison, ">= 1.5.0"},
      {:plug, "~> 1.0"},
      {:cowboy, "~> 1.0", only: [:test, :dev]},


### PR DESCRIPTION
Rather than depending on specific (~>) versions of bamboo and hackney we
should just declare them as a minimum (=>).