### PR TITLE
Allow reading api key from system environment variable

### DIFF
--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -79,10 +79,16 @@ defmodule Bamboo.PostmarkAdapter do
   end
 
   defp get_key(config) do
-    if config[:api_key] in [nil, ""] do
+    api_key =
+      case Map.get(config, :api_key) do
+        {:system, var} -> System.get_env(var)
+        key -> key
+      end
+
+    if api_key in [nil, ""] do
       raise_api_key_error(config)
     else
-      config[:api_key]
+      api_key
     end
   end
 


### PR DESCRIPTION
Fixed https://github.com/pablo-co/bamboo_postmark/issues/25

Borrowing the logic from sendgrid adapter: https://github.com/thoughtbot/bamboo/blob/34cd76df94ca58bf75c8e442178de9db7fac75f3/lib/bamboo/adapters/send_grid_adapter.ex#L66-L70