### PR TITLE
Don't suggest user's to add `:bamboo` in their `:applications`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,7 @@ def deps do
 end
 ```
 
-2. Ensure bamboo is started before your application:
-
-```elixir
-def application do
-  [applications: [:bamboo]]
-end
-```
-
-3. Add your Postmark API key to your config
+2. Add your Postmark API key to your config
 
 > You can find this key as `Server API token` under the `Credentials` tab in each Postmark server.
 
@@ -43,7 +35,7 @@ config :my_app, MyApp.Mailer,
       # api_key: {:system, "POSTMARK_API_KEY"}
 ```
 
-4. Follow Bamboo [Getting Started Guide](https://github.com/thoughtbot/bamboo#getting-started)
+3. Follow Bamboo [Getting Started Guide](https://github.com/thoughtbot/bamboo#getting-started)
 
 ## Using templates
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule BambooPostmark.Mixfile do
   def project do
     [app: :bamboo_postmark,
      version: "0.6.0",
-     elixir: "~> 1.2",
+     elixir: "~> 1.4",
      source_url: @project_url,
      homepage_url: @project_url,
      name: "Bamboo Postmark Adapter",
@@ -18,7 +18,7 @@ defmodule BambooPostmark.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :hackney]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do

--- a/test/lib/bamboo/postmark_adapter_test.exs
+++ b/test/lib/bamboo/postmark_adapter_test.exs
@@ -183,7 +183,7 @@ defmodule Bamboo.PostmarkAdapterTest do
 
   test "deliver/2 puts template name and content" do
     email = PostmarkHelper.template(new_email(), "hello", [
-      %{name: 'example name', content: 'example content'}
+      %{name: "example name", content: "example content"}
     ])
 
     PostmarkAdapter.deliver(email, @config)
@@ -191,8 +191,8 @@ defmodule Bamboo.PostmarkAdapterTest do
     assert_receive {:fake_postmark, %{params: %{"TemplateId" => template_id,
        "TemplateModel" => template_model}}}
     assert template_id == "hello"
-    assert template_model == [%{"content" => 'example content',
-      "name" => 'example name'}]
+    assert template_model == [%{"content" => "example content",
+      "name" => "example name"}]
   end
 
   test "deliver/2 puts tag param" do


### PR DESCRIPTION
Elixir 1.4 added application inference which makes
that unecessary. It is generally recommended to not set `:applications`,
but instead only set `:extra_applications`, but since Elixir 1.4 was
released in 2017 I don't think we need to add any instructions for users
still on Elixir 1.3 and earlier.

Additionally if the user only has set some of the applications in
`:applications` there won't be a problem until they try to run a release.

Also adjust the minimum supported version of Elixir to 1.4 to make use
of `:extra_applications`

And change some charlists to strings in the test file.