### PR TITLE
Support the use of TemplateAlias

### DIFF
--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -69,7 +69,7 @@ defmodule Bamboo.PostmarkAdapter do
     raise ArgumentError, """
     There was no API key set for the Postmark adapter.
     * Here are the config options that were passed in:
-    #{inspect config}
+    #{inspect(config)}
     """
   end
 
@@ -87,22 +87,26 @@ defmodule Bamboo.PostmarkAdapter do
 
   def maybe_put_attachments(params, %{attachments: attachments}) do
     params
-    |> Map.put(:"Attachments", Enum.map(attachments, fn attachment ->
-      %{
-        Name: attachment.filename,
-        Content: attachment.data |> Base.encode64(),
-        ContentType: attachment.content_type,
-        ContentId: attachment.content_id
-      }
-    end))
+    |> Map.put(
+      :Attachments,
+      Enum.map(attachments, fn attachment ->
+        %{
+          Name: attachment.filename,
+          Content: attachment.data |> Base.encode64(),
+          ContentType: attachment.content_type,
+          ContentId: attachment.content_id
+        }
+      end)
+    )
   end
 
-  defp maybe_put_template_params(params, %{private:
-    %{template_id: template_name, template_model: template_model}}) do
-    params
-    |> Map.put(:"TemplateId", template_name)
-    |> Map.put(:"TemplateModel", template_model)
-    |> Map.put(:"InlineCss", true)
+  defp maybe_put_template_params(params, %{private: %{template_model: template_model} = private}) do
+    case private do
+      %{template_id: template_id} -> Map.put(params, :TemplateId, template_id)
+      %{template_alias: template_alias} -> Map.put(params, :TemplateAlias, template_alias)
+    end
+    |> Map.put(:TemplateModel, template_model)
+    |> Map.put(:InlineCss, true)
   end
 
   defp maybe_put_template_params(params, _) do
@@ -110,7 +114,7 @@ defmodule Bamboo.PostmarkAdapter do
   end
 
   defp maybe_put_tag_params(params, %{private: %{tag: tag}}) do
-    Map.put(params, :"Tag", tag)
+    Map.put(params, :Tag, tag)
   end
 
   defp maybe_put_tag_params(params, _) do
@@ -119,29 +123,39 @@ defmodule Bamboo.PostmarkAdapter do
 
   defp email_params(email) do
     recipients = recipients(email)
-    add_message_params(%{
-                         "From": email_from(email),
-                         "To": recipients_to_string(recipients, "To"),
-                         "Cc": recipients_to_string(recipients, "Cc"),
-                         "Bcc": recipients_to_string(recipients, "Bcc"),
-                         "Subject": email.subject,
-                         "TextBody": email.text_body,
-                         "HtmlBody": email.html_body,
-                         "Headers": email_headers(email),
-                         "TrackOpens": true
-                       }, email)
+
+    params = %{
+      From: email_from(email),
+      To: recipients_to_string(recipients, "To"),
+      Cc: recipients_to_string(recipients, "Cc"),
+      Bcc: recipients_to_string(recipients, "Bcc"),
+      Subject: email.subject,
+      Headers: email_headers(email),
+      TrackOpens: true
+    }
+
+    params =
+      case email do
+        %{private: %{template_id: _}} -> params
+        %{private: %{template_alias: _}} -> params
+        _ -> Map.merge(params, %{TextBody: email.text_body, HtmlBody: email.html_body})
+      end
+
+    add_message_params(params, email)
   end
 
   defp add_message_params(params, %{private: %{message_params: message_params}}) do
-    Enum.reduce(message_params, params, fn({key, value}, params) ->
+    Enum.reduce(message_params, params, fn {key, value}, params ->
       Map.put(params, key, value)
     end)
   end
+
   defp add_message_params(params, _), do: params
 
   defp email_from(email) do
     name = elem(email.from, 0)
     email = elem(email.from, 1)
+
     if name do
       String.trim("#{name} <#{email}>")
     else
@@ -150,8 +164,10 @@ defmodule Bamboo.PostmarkAdapter do
   end
 
   defp email_headers(email) do
-    Enum.map(email.headers,
-              fn {header, value} -> %{"Name": header, "Value": value} end)
+    Enum.map(
+      email.headers,
+      fn {header, value} -> %{Name: header, Value: value} end
+    )
   end
 
   defp recipients(email) do
@@ -162,28 +178,34 @@ defmodule Bamboo.PostmarkAdapter do
   end
 
   defp add_recipients(recipients, new_recipients, type: recipient_type) do
-    Enum.reduce(new_recipients, recipients, fn(recipient, recipients) ->
-      recipients ++ [%{
-        name: elem(recipient, 0),
-        email: elem(recipient, 1),
-        type: recipient_type
-      }]
+    Enum.reduce(new_recipients, recipients, fn recipient, recipients ->
+      recipients ++
+        [
+          %{
+            name: elem(recipient, 0),
+            email: elem(recipient, 1),
+            type: recipient_type
+          }
+        ]
     end)
   end
 
   defp recipients_to_string(recipients, type) do
     recipients
-    |> Enum.filter(fn(recipient) -> recipient[:type] == type end)
-    |> Enum.map_join(",", fn(rec) -> "#{rec[:name]} <#{rec[:email]}>" end)
+    |> Enum.filter(fn recipient -> recipient[:type] == type end)
+    |> Enum.map_join(",", fn rec -> "#{rec[:name]} <#{rec[:email]}>" end)
   end
 
   defp headers(api_key) do
-    [{"accept", "application/json"},
-     {"content-type", "application/json"},
-     {"x-postmark-server-token", api_key}]
+    [
+      {"accept", "application/json"},
+      {"content-type", "application/json"},
+      {"x-postmark-server-token", api_key}
+    ]
   end
 
   defp api_path(%{private: %{template_id: _}}), do: @send_email_template_path
+  defp api_path(%{private: %{template_alias: _}}), do: @send_email_template_path
   defp api_path(_), do: @send_email_path
 
   defp base_uri do
@@ -191,6 +213,6 @@ defmodule Bamboo.PostmarkAdapter do
   end
 
   defp options(config) do
-    Keyword.merge(config[:request_options] || [], [with_body: true])
+    Keyword.merge(config[:request_options] || [], with_body: true)
   end
 end

--- a/lib/bamboo/postmark_helper.ex
+++ b/lib/bamboo/postmark_helper.ex
@@ -32,12 +32,21 @@ defmodule Bamboo.PostmarkHelper do
 
       template(email, "9746128")
       template(email, "9746128", %{"name" => "Name", "content" => "John"})
+      template(email, {:alias, "my-template-alias"}, %{"name" => "Name", "content" => "John"})
 
   """
   def template(email, template_id, template_model \\ %{}) do
     email
-    |> Email.put_private(:template_id, template_id)
     |> Email.put_private(:template_model, template_model)
+    |> put_private_template(template_id)
+  end
+
+  defp put_private_template(email, {:alias, template_alias}) do
+    Email.put_private(email, :template_alias, template_alias)
+  end
+
+  defp put_private_template(email, template_id) do
+    Email.put_private(email, :template_id, template_id)
   end
 
   @doc """
@@ -60,6 +69,7 @@ defmodule Bamboo.PostmarkHelper do
   def put_param(%Email{private: %{message_params: _}} = email, key, value) do
     put_in(email.private[:message_params][key], value)
   end
+
   def put_param(email, key, value) do
     email
     |> Email.put_private(:message_params, %{})


### PR DESCRIPTION
Hi! Thanks for the work on this library!

Instead of requiring `TemplateId` to be passed in, this allows `TemplateAlias` to be used instead, via:

`email |> template({:alias, "my-template-alias"})`

This PR also includes another important fix: when a template is passed into the request, if the `HtmlBody` or `TextBody` keys are present (even if the values are `null`), Postmark responds with: `{"ErrorCode":402,"Message":"Received invalid JSON input."}` 🙄 

I've removed the inclusion of these keys in the request if a template is used.