### PR TITLE
Encode names to support special characters

### DIFF
--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -176,7 +176,8 @@ defmodule Bamboo.PostmarkAdapter do
   defp encode_name_and_email(name, email) do
     encoded =
       if name do
-        "#{name} <#{email}>"
+        name = String.replace(name, ~s("), ~s(\\"))
+        ~s("#{name}" <#{email}>)
       else
         email
       end

--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -142,11 +142,7 @@ defmodule Bamboo.PostmarkAdapter do
   defp email_from(email) do
     name = elem(email.from, 0)
     email = elem(email.from, 1)
-    if name do
-      String.trim("#{name} <#{email}>")
-    else
-      String.trim(email)
-    end
+    encode_name_and_email(name, email)
   end
 
   defp email_headers(email) do
@@ -174,7 +170,18 @@ defmodule Bamboo.PostmarkAdapter do
   defp recipients_to_string(recipients, type) do
     recipients
     |> Enum.filter(fn(recipient) -> recipient[:type] == type end)
-    |> Enum.map_join(",", fn(rec) -> "#{rec[:name]} <#{rec[:email]}>" end)
+    |> Enum.map_join(",", &encode_name_and_email(&1.name, &1.email))
+  end
+
+  defp encode_name_and_email(name, email) do
+    encoded =
+      if name do
+        "#{name} <#{email}>"
+      else
+        email
+      end
+
+    String.trim(encoded)
   end
 
   defp headers(api_key) do

--- a/test/lib/bamboo/postmark_adapter_test.exs
+++ b/test/lib/bamboo/postmark_adapter_test.exs
@@ -148,7 +148,7 @@ defmodule Bamboo.PostmarkAdapterTest do
     PostmarkAdapter.deliver(email, @config)
 
     assert_receive {:fake_postmark, %{params: params}}
-    assert params["From"] == "#{elem(email.from, 0)} <#{elem(email.from, 1)}>"
+    assert params["From"] == ~s("#{elem(email.from, 0)}" <#{elem(email.from, 1)}>)
     assert params["Subject"] == email.subject
     assert params["TextBody"] == email.text_body
     assert params["HtmlBody"] == email.html_body
@@ -166,9 +166,18 @@ defmodule Bamboo.PostmarkAdapterTest do
     PostmarkAdapter.deliver(email, @config)
 
     assert_receive {:fake_postmark, %{params: params}}
-    assert params["To"] == "To <to@bar.com>"
-    assert params["Bcc"] == "BCC <bcc@bar.com>"
-    assert params["Cc"] == "CC <cc@bar.com>"
+    assert params["To"] == ~s("To" <to@bar.com>)
+    assert params["Bcc"] == ~s("BCC" <bcc@bar.com>)
+    assert params["Cc"] == ~s("CC" <cc@bar.com>)
+  end
+
+  test "deliver/2 escapes special characters in names" do
+    email = new_email(to: [{"João \"Fulano", "to@bar.com"}])
+
+    PostmarkAdapter.deliver(email, @config)
+
+    assert_receive {:fake_postmark, %{params: params}}
+    assert params["To"] == ~s("João \\"Fulano" <to@bar.com>)
   end
 
   test "deliver/2 puts template name and empty content" do


### PR DESCRIPTION
This PR encodes names with quotes when building e-mails, e.g. `"John Doe" <johndoe@provider.test>`. This adds support for special names with commas and even quotes.

Related: https://github.com/symfony/symfony/pull/39866, https://github.com/plausible/analytics/issues/1885