### PR TITLE
Add support for template alias

### DIFF
--- a/lib/bamboo/postmark_adapter.ex
+++ b/lib/bamboo/postmark_adapter.ex
@@ -98,9 +98,14 @@ defmodule Bamboo.PostmarkAdapter do
   end
 
   defp maybe_put_template_params(params, %{private:
-    %{template_id: template_name, template_model: template_model}}) do
+    %{template_model: template_model} = private}) do
+    params =
+      case private do
+        %{template_id: template_id} -> Map.put(params, :"TemplateId", template_id)
+        %{template_alias: template_alias} -> Map.put(params, :"TemplateAlias", template_alias)
+      end
+
     params
-    |> Map.put(:"TemplateId", template_name)
     |> Map.put(:"TemplateModel", template_model)
     |> Map.put(:"InlineCss", true)
   end

--- a/lib/bamboo/postmark_helper.ex
+++ b/lib/bamboo/postmark_helper.ex
@@ -34,7 +34,15 @@ defmodule Bamboo.PostmarkHelper do
       template(email, "9746128", %{"name" => "Name", "content" => "John"})
 
   """
-  def template(email, template_id, template_model \\ %{}) do
+  def template(email, template_id_or_alias, template_model \\ %{})
+
+  def template(email, {:alias, template_alias}, template_model) do
+    email
+    |> Email.put_private(:template_alias, template_alias)
+    |> Email.put_private(:template_model, template_model)
+  end
+
+  def template(email, template_id, template_model) do
     email
     |> Email.put_private(:template_id, template_id)
     |> Email.put_private(:template_model, template_model)

--- a/test/lib/bamboo/postmark_adapter_test.exs
+++ b/test/lib/bamboo/postmark_adapter_test.exs
@@ -171,7 +171,7 @@ defmodule Bamboo.PostmarkAdapterTest do
     assert params["Cc"] == "CC <cc@bar.com>"
   end
 
-  test "deliver/2 puts template name and empty content" do
+  test "deliver/2 puts template id and empty content" do
     email = PostmarkHelper.template(new_email(), "hello")
 
     PostmarkAdapter.deliver(email, @config)
@@ -182,7 +182,7 @@ defmodule Bamboo.PostmarkAdapterTest do
     assert template_model == %{}
   end
 
-  test "deliver/2 puts template name and content" do
+  test "deliver/2 puts template id and content" do
     email = PostmarkHelper.template(new_email(), "hello", [
       %{name: "example name", content: "example content"}
     ])
@@ -192,6 +192,31 @@ defmodule Bamboo.PostmarkAdapterTest do
     assert_receive {:fake_postmark, %{params: %{"TemplateId" => template_id,
        "TemplateModel" => template_model}}}
     assert template_id == "hello"
+    assert template_model == [%{"content" => "example content",
+      "name" => "example name"}]
+  end
+
+  test "deliver/2 puts template alias and empty content" do
+    email = PostmarkHelper.template(new_email(), {:alias, "hello_alias"})
+
+    PostmarkAdapter.deliver(email, @config)
+
+    assert_receive {:fake_postmark, %{params: %{"TemplateAlias" => template_alias,
+       "TemplateModel" => template_model}}}
+    assert template_alias == "hello_alias"
+    assert template_model == %{}
+  end
+
+  test "deliver/2 puts template alias and content" do
+    email = PostmarkHelper.template(new_email(), {:alias, "hello_alias"}, [
+      %{name: "example name", content: "example content"}
+    ])
+
+    PostmarkAdapter.deliver(email, @config)
+
+    assert_receive {:fake_postmark, %{params: %{"TemplateAlias" => template_alias,
+       "TemplateModel" => template_model}}}
+    assert template_alias == "hello_alias"
     assert template_model == [%{"content" => "example content",
       "name" => "example name"}]
   end


### PR DESCRIPTION
Hey Pablo,

This is PR is entirely based on #40 by @nkezhaya without the formatting changes and I added a couple of test cases. I also removed the fix when passing `HtmlBody` or `TextBody` along with a template, that can be a followup PR.

I hope this finds you well!